### PR TITLE
Implement sMouse rounding natively to LIBMACT GetMouseDelta()

### DIFF
--- a/blood/src/config.cpp
+++ b/blood/src/config.cpp
@@ -50,6 +50,7 @@ int32 MidiPort;
 int32 ReverseStereo;
 controltype ControllerType;
 int32 gMouseSensitivity;
+int32 gMouseAxisSensitivity[2] = {65536L, 65536L};
 int32 gMouseAiming;
 BOOL gMouseAimingFlipped;
 int32 gTurnSpeed = 92;
@@ -450,6 +451,7 @@ void CONFIG_SetupMouse( int32 scripthandle )
       sprintf(str,"MouseAnalogScale%ld",i);
       SCRIPT_GetNumber(scripthandle, "Controls", str,&scale);
       CONTROL_SetAnalogAxisScale( i, scale );
+      gMouseAxisSensitivity[i] = scale;
       }
 
    SCRIPT_GetNumber( scripthandle, "Controls","MouseSensitivity",&gMouseSensitivity);

--- a/blood/src/config.h
+++ b/blood/src/config.h
@@ -37,6 +37,7 @@ extern int32 NumChannels;
 extern int32 NumBits;
 extern int32 MixRate;
 extern int32 gMouseSensitivity;
+extern int32 gMouseAxisSensitivity[2];
 extern int32 ScreenMode;
 extern int32 ScreenHeight;
 extern int32 ScreenWidth;


### PR DESCRIPTION
This PR improves the mouse calculation used by MACT library much like bMouse/sMouse, without having to use the external driver. It's been hand optimized with assembly as to run with little performance impact compared to the original code.

I understand if you wish to recline this PR as it may impact the intended experience of having horrible mouse look, but I figured it was worth attempting to PR to another fork.